### PR TITLE
Add proxy BEFORE opening socket

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -177,10 +176,11 @@ Package.prototype.getJSON = function(fn){
 
   debug('fetching %s', url);
   var req = request.get(url);
-  req.set('Accept-Encoding', 'gzip');
 
   // Add proxy
   if (this.proxy) req.proxy(this.proxy);
+
+  req.set('Accept-Encoding', 'gzip');
 
   // authorize call
   var hostname = parse(url).hostname;


### PR DESCRIPTION
setting a request header creates the actual request object (calls Request.request()) which - for https urls - creates a new http.ClientRequest with options.createConnection to be called in ClientRequest constructor and which initiates connect on the socket. So -> proxy should be called first
