### PR TITLE
Bitbucket support

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,19 @@ Package.prototype.url = function(file){
     ? this.remote.href
     : this.remotes[0];
 
-  return remote + '/' + this.name + '/' + this.version + '/' + file;
+  var resolved_url = remote + '/' + this.name + '/' + this.version + '/' + file;
+
+  if(this.remote) {
+    switch(this.remote.host) {
+      case 'bitbucket.org':
+        resolved_url = remote + '/' + this.name + '/raw/' + this.version + '/' + file;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return resolved_url;
 };
 
 /**


### PR DESCRIPTION
Since Bitbucket raw url different from Github.
Github: https://raw.githubusercontent.com
Bitbucket: https://bitbucket.com/username/repo/raw/

Component remotes: https://username_or_email:password@bitbucket.org
