### PR TITLE
Detect when download produced an empty file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -240,7 +239,18 @@ Package.prototype.getFiles = function(files, fn){
           var stream = fs.createWriteStream(dst);
           stream.on('error', done);
           res.pipe(stream);
-          res.on('end', done);
+          res.on('end', function () {
+            if (!res.headers['content-length']) {
+              return done();
+            }
+            fs.stat(dst, function (err, stats) {
+              if (err) return done(err);
+              if (stats.size === 0) {
+                return done(new Error(url + ' to ' + dst + ' produced empty file'));
+              }
+              done();
+            });
+          });
         });
 
         req.end();

--- a/index.js
+++ b/index.js
@@ -239,17 +239,14 @@ Package.prototype.getFiles = function(files, fn){
           var stream = fs.createWriteStream(dst);
           stream.on('error', done);
           res.pipe(stream);
-          res.on('end', function () {
+          stream.on('finish', function () {
             if (!res.headers['content-length']) {
               return done();
             }
-            fs.stat(dst, function (err, stats) {
-              if (err) return done(err);
-              if (stats.size === 0) {
-                return done(new Error(url + ' to ' + dst + ' produced empty file'));
-              }
-              done();
-            });
+            if (stream.bytesWritten !== parseInt(res.headers['content-length'])) {
+              return done(new Error(url + ' to ' + dst + ' produced wrong file'));
+            }
+            done();
           });
         });
 

--- a/index.js
+++ b/index.js
@@ -72,11 +72,11 @@ function Package(pkg, version, options) {
   this.proxy = options.proxy || process.env.https_proxy;
   this.version = version;
   this.concurrency = options.concurrency;
-  if (inFlight[this.slug]) {
+  if (inFlight[this.dest + this.slug]) {
     this.install = this.emit.bind(this, 'end');
     this.inFlight = true;
   }
-  inFlight[this.slug] = true;
+  inFlight[this.dest + this.slug] = true;
 }
 
 /**


### PR DESCRIPTION
If the remote provides a non-zero file size (via the `content-length` header), check the size of the created file at end of download, and throw error if we got an empty file.

This is made for detecting component/installer.js#12
